### PR TITLE
rename plugin so it sits last in the dependency list (cordova 7.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.8.3",
   "description": "Localytics Plugin for Cordova/PhoneGap",
   "cordova": {
-    "id": "com.localytics.phonegap.LocalyticsPlugin",
+    "id": "zzz.com.localytics.phonegap.LocalyticsPlugin",
     "platforms": [
       "ios",
       "android"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="com.localytics.phonegap.LocalyticsPlugin"  xmlns:android="http://schemas.android.com/apk/res/android" version="1.0.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="zzz.com.localytics.phonegap.LocalyticsPlugin"  xmlns:android="http://schemas.android.com/apk/res/android" version="1.0.0">
     <name>Localytics</name>
     <description>Localytics Plugin for Cordova/PhoneGap</description>
     <license>Apache 2.0</license>
@@ -38,7 +38,7 @@
 
         <config-file target="config.xml" parent="/*">
             <feature name="LocalyticsPlugin" >
-                <param name="android-package" value="com.localytics.phonegap.LocalyticsPlugin"/>
+                <param name="android-package" value="zzz.com.localytics.phonegap.LocalyticsPlugin"/>
             </feature>
         </config-file>
 


### PR DESCRIPTION
Cordova 7.x now sorts cordova plugin library dependencies alphabetically. Plugin order matters, as multiple plugins implement openUrl functionality and one will block out the other.