### PR TITLE
revert config change

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,7 +38,7 @@
 
         <config-file target="config.xml" parent="/*">
             <feature name="LocalyticsPlugin" >
-                <param name="android-package" value="zzz.com.localytics.phonegap.LocalyticsPlugin"/>
+                <param name="android-package" value="com.localytics.phonegap.LocalyticsPlugin"/>
             </feature>
         </config-file>
 


### PR DESCRIPTION
This crashes the app on Android. Only needed to change the plugin name.