### PR TITLE
remove unused play-services-ads

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -52,7 +52,6 @@
 
         <framework src="com.android.support:support-v4:+" />
         <framework src="com.google.android.gms:play-services-gcm:+" />
-        <framework src="com.google.android.gms:play-services-ads:+" />
 
     </platform>
 


### PR DESCRIPTION
Remove unused google admob service which is required to specify app ID during android init